### PR TITLE
add trust_remote_code for hellaswag

### DIFF
--- a/lm_eval/models/neuron_optimum.py
+++ b/lm_eval/models/neuron_optimum.py
@@ -288,7 +288,7 @@ class NEURON_HF(TemplateLM):
 
         self.vocab_size = self.tokenizer.vocab_size
         self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
-        self.add_bos_token = self.add_bos_token
+        self.add_bos_token = add_bos_token
 
         self._max_length = max_length
 

--- a/lm_eval/tasks/hellaswag/hellaswag.yaml
+++ b/lm_eval/tasks/hellaswag/hellaswag.yaml
@@ -20,3 +20,5 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 1.0
+dataset_kwargs:
+  trust_remote_code: true

--- a/lm_eval/tasks/piqa/piqa.yaml
+++ b/lm_eval/tasks/piqa/piqa.yaml
@@ -19,3 +19,5 @@ metric_list:
     higher_is_better: true
 metadata:
   version: 1.0
+dataset_kwargs:
+  trust_remote_code: true


### PR DESCRIPTION
I noticed that hellaswag needs trust_remote code to be set to True. Fixing this similar to with other similar tasks

https://github.com/EleutherAI/lm-evaluation-harness/issues/1985
https://github.com/EleutherAI/lm-evaluation-harness/pull/1487

Error:
2024-06-19T04:53:08.486Z	ValueError: The repository for hellaswag contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/hellaswag.
2024-06-19T04:53:08.486Z	Please pass the argument `trust_remote_code=True` to allow custom code to be run.
2024-06-19T04:53:09.487Z	The repository for hellaswag contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/hellaswag.
2024-06-19T04:53:09.487Z	You can avoid this prompt in future by passing the argument `trust_remote_code=True`.